### PR TITLE
Update run.py

### DIFF
--- a/xeneta_qualifier/run.py
+++ b/xeneta_qualifier/run.py
@@ -26,7 +26,7 @@ def runForest(X_train, y_train):
 
 # Stochastic Gradient Descent Classifier
 def runSGD(X_train, y_train):
-    sgd = SGDClassifier(n_iter=500, loss='modified_huber', penalty='elasticnet', random_state=42)
+    sgd = SGDClassifier(max_iter=500, loss='modified_huber', penalty='elasticnet', random_state=42)
     sgd.fit(X_train, y_train)
     return sgd
  


### PR DESCRIPTION
Removed n_iter in favor of the new max_iter. Performance and accuracy is consistent. The change was because n_iter is being deprecated and will be removed in sklearn 0.21 according the the deprecation warning.